### PR TITLE
Add stopping criteria

### DIFF
--- a/src/main/java/com/sigopt/model/Experiment.java
+++ b/src/main/java/com/sigopt/model/Experiment.java
@@ -119,11 +119,9 @@ public class Experiment extends StructObject {
     }
 
     /**
-    *   LinkedResource is used for a resource linked strongly to another.
-    *   One example is StoppingCriteria, which isn't a
-    *   full object with its own id but still must be
-    *   retrieved as its own resource (separate from Experiment, in the case of)
-    *   Stopping Criteria.
+    *   LinkedResource is used for a resource linked strongly to another e.g.
+    *   StoppingCriteria isn't a full object with its own id but still must be
+    *   retrieved as its own resource separate from Experiment
     */
     public static class LinkedResource<T extends APIObject> extends BoundObject {
         String name;

--- a/src/main/java/com/sigopt/model/Experiment.java
+++ b/src/main/java/com/sigopt/model/Experiment.java
@@ -83,7 +83,7 @@ public class Experiment extends StructObject {
     }
 
     public static APIMethodCaller<Experiment> fetch(String id) {
-        return Experiment.fetch().addParam("id", id);
+        return Experiment.fetch().addPathComponent("id", id);
     }
 
     public static PaginatedAPIMethodCaller<Experiment> list() {
@@ -153,7 +153,7 @@ public class Experiment extends StructObject {
         }
 
         public APIMethodCaller<T> fetch(String id) {
-            return this.fetch().addPathComponent("id", id);
+            return this.fetch().addParam("id", id);
         }
 
         public PaginatedAPIMethodCaller<T> list() {

--- a/src/main/java/com/sigopt/model/Experiment.java
+++ b/src/main/java/com/sigopt/model/Experiment.java
@@ -83,7 +83,7 @@ public class Experiment extends StructObject {
     }
 
     public static APIMethodCaller<Experiment> fetch(String id) {
-        return Experiment.fetch().addPathComponent("id", id);
+        return Experiment.fetch().addParam("id", id);
     }
 
     public static PaginatedAPIMethodCaller<Experiment> list() {

--- a/src/main/java/com/sigopt/model/Experiment.java
+++ b/src/main/java/com/sigopt/model/Experiment.java
@@ -119,15 +119,15 @@ public class Experiment extends StructObject {
     }
 
     /**
-    *   LinkedResource is used for a resource linked strongly to another e.g.
+    *   PropertyResource is used for a resource linked strongly to another e.g.
     *   StoppingCriteria isn't a full object with its own id but still must be
     *   retrieved as its own resource separate from Experiment
     */
-    public static class LinkedResource<T extends APIObject> extends BoundObject {
+    public static class PropertyResource<T extends APIObject> extends BoundObject {
         String name;
         Class<T> klass;
 
-        public LinkedResource(String prefix, String name, Class<T> klass) {
+        public PropertyResource(String prefix, String name, Class<T> klass) {
             super(prefix);
             this.name = name;
             this.klass = klass;
@@ -153,7 +153,7 @@ public class Experiment extends StructObject {
         }
 
         public APIMethodCaller<T> fetch(String id) {
-            return this.fetch().addParam("id", id);
+            return this.fetch().addPathComponent("id", id);
         }
 
         public PaginatedAPIMethodCaller<T> list() {
@@ -197,8 +197,8 @@ public class Experiment extends StructObject {
         return new Subresource<Observation>("/experiments/" + this.getId(), "observations", Observation.class);
     }
 
-    public LinkedResource<StoppingCriteria> stoppingCriteria() {
-        return new LinkedResource<StoppingCriteria>("/experiments/" + this.getId(), "stopping_criteria", StoppingCriteria.class);
+    public PropertyResource<StoppingCriteria> stoppingCriteria() {
+        return new PropertyResource<StoppingCriteria>("/experiments/" + this.getId(), "stopping_criteria", StoppingCriteria.class);
     }
 
     public Subresource<Suggestion> suggestions() {

--- a/src/main/java/com/sigopt/model/Experiment.java
+++ b/src/main/java/com/sigopt/model/Experiment.java
@@ -118,6 +118,28 @@ public class Experiment extends StructObject {
         return Experiment.delete().addPathComponent("id", id);
     }
 
+    /**
+    *   LinkedResource is used for a resource linked strongly to another.
+    *   One example is StoppingCriteria, which isn't a
+    *   full object with its own id but still must be
+    *   retrieved as its own resource (separate from Experiment, in the case of)
+    *   Stopping Criteria.
+    */
+    public static class LinkedResource<T extends APIObject> extends BoundObject {
+        String name;
+        Class<T> klass;
+
+        public LinkedResource(String prefix, String name, Class<T> klass) {
+            super(prefix);
+            this.name = name;
+            this.klass = klass;
+        }
+
+        public APIMethodCaller<T> fetch() {
+            return new APIMethodCaller<T>("get", this.prefix() + "/" + this.name, klass);
+        }
+    }
+
     public static class Subresource<T extends APIObject> extends BoundObject {
         String name;
         Class<T> klass;
@@ -175,6 +197,10 @@ public class Experiment extends StructObject {
 
     public Subresource<Observation> observations() {
         return new Subresource<Observation>("/experiments/" + this.getId(), "observations", Observation.class);
+    }
+
+    public LinkedResource<StoppingCriteria> stoppingCriteria() {
+        return new LinkedResource<StoppingCriteria>("/experiments/" + this.getId(), "stopping_criteria", StoppingCriteria.class);
     }
 
     public Subresource<Suggestion> suggestions() {

--- a/src/main/java/com/sigopt/model/StoppingCriteria.java
+++ b/src/main/java/com/sigopt/model/StoppingCriteria.java
@@ -1,0 +1,42 @@
+package com.sigopt.model;
+
+import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StoppingCriteria extends StructObject {
+	public StoppingCriteria() {
+		super();
+	}
+
+	public Boolean getShouldStop() {
+		return (Boolean) this.get("should_stop");
+	}
+
+  public List<String> getReasons() {
+    return (List<String>) this.get("reasons");
+  }
+
+  public static class Builder {
+    StoppingCriteria s;
+    public Builder() {
+      this.s = new StoppingCriteria();
+    }
+
+    public StoppingCriteria build() {
+      return this.s;
+    }
+
+    public Builder shouldStop(Boolean shouldStop) {
+      this.s.set("should_stop", shouldStop);
+      return this;
+    }
+
+    public Builder reasons(List<String> reasons) {
+      this.s.set("reasons", reasons);
+      return this;
+    }
+
+  }
+
+}

--- a/src/main/java/com/sigopt/net/PathBuilder.java
+++ b/src/main/java/com/sigopt/net/PathBuilder.java
@@ -9,6 +9,12 @@ import java.util.regex.Pattern;
 
 class PathBuilder {
     public static String build(String path, Map<String, String> params) {
+        System.out.println("Path: " + path);
+        for(String key : params.keySet()) {
+            System.out.println("Key: " + key);
+            System.out.println("Value: " + params.get(key));
+        }
+
         params = MapHelper.ensure(params);
 
         Pattern r = Pattern.compile(":([^\\/]*)");

--- a/src/main/java/com/sigopt/net/PathBuilder.java
+++ b/src/main/java/com/sigopt/net/PathBuilder.java
@@ -9,12 +9,6 @@ import java.util.regex.Pattern;
 
 class PathBuilder {
     public static String build(String path, Map<String, String> params) {
-        System.out.println("Path: " + path);
-        for(String key : params.keySet()) {
-            System.out.println("Key: " + key);
-            System.out.println("Value: " + params.get(key));
-        }
-
         params = MapHelper.ensure(params);
 
         Pattern r = Pattern.compile(":([^\\/]*)");

--- a/src/test/java/com/sigopt/model/StoppingCriteriaTest.java
+++ b/src/test/java/com/sigopt/model/StoppingCriteriaTest.java
@@ -1,0 +1,36 @@
+package com.sigopt.model;
+
+import com.sigopt.model.APIResource;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class StoppingCriteriaTest extends APIResourceTestBase {
+    String json;
+
+    @BeforeClass
+    public static void setUp() {
+    }
+
+    @Before
+    public void setUpMockData() throws IOException {
+        json = resource("stoppingCriteria.json");
+    }
+
+    @Test
+    public void constructFromJson() throws Exception {
+        StoppingCriteria b = APIResource.constructFromJson(json, StoppingCriteria.class);
+
+        assertEquals(true, b.getShouldStop());
+        assertNotNull(b.getReasons());
+        assertTrue(b.getReasons().contains("observation_budget_reached"));
+        assertTrue(b.getReasons().contains("possible_stagnation"));
+    }
+}

--- a/src/test/resources/com/sigopt/model/stoppingCriteria.json
+++ b/src/test/resources/com/sigopt/model/stoppingCriteria.json
@@ -1,0 +1,7 @@
+{
+  "should_stop": true,
+  "reasons": [
+    "observation_budget_reached",
+    "possible_stagnation"
+  ]
+}


### PR DESCRIPTION
Asana Task: https://app.asana.com/0/38684300131201/357028383074880

One potentially controversial change I made is added the LinkedResource class. I commented what this does, but the reason I did this was because StoppingCriteria is actually the first resource that doesn't have its own id/wouldn't be POSTed or UPDATEd and isn't a paginated list (like best_assignments). Since I could not add stopping criteria to the client with the Subresource.fetch() function, I thought it made sense that while something like observation was a "subresource,"  stopping_criteria was more of a "linked resource."

Let me know if there is another way of doing this that makes more sense.

If we did it this way, I'd also update the documentation which says that the developer accesses stopping_criteria with 

`new Experiment(EXPERIMENT_ID).stopping_criteria().list().call()`

^That didn't make sense to me since the response to /stopping_criteria is not a paginated list.