### PR TITLE
Fixing fetch bug

### DIFF
--- a/src/main/java/com/sigopt/model/Experiment.java
+++ b/src/main/java/com/sigopt/model/Experiment.java
@@ -153,7 +153,7 @@ public class Experiment extends StructObject {
         }
 
         public APIMethodCaller<T> fetch(String id) {
-            return this.fetch().addParam("id", id);
+            return this.fetch().addPathComponent("id", id);
         }
 
         public PaginatedAPIMethodCaller<T> list() {


### PR DESCRIPTION
Found this bug as I was adding stopping criteria to the Java client. 

Before, https://sigopt.com/docs/endpoints/suggestions/detail and https://sigopt.com/docs/endpoints/observations/detail were actually broken. In the fetch(String id) function in the Subresource class we should be adding the id as a path component, but we are doing it as a param, which is incorrect. 

@alexandraj777 