### PR TITLE
Remove travis Oracle JDK 7 configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 jdk:
   - openjdk7
   - openjdk8
-  - oraclejdk7
   - oraclejdk8
 
 sudo: false


### PR DESCRIPTION
Oracle has removed public support for JDK 7

> #### Java SE 7 and Java SE 6 updates
> Updates for Java SE 7 released after April 2015, and updates for Java SE 6 released after April 2013 are only available to Oracle Customers through My Oracle Support (requires support login).

http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html