### PR TITLE
Expose .get/.set publicly

### DIFF
--- a/src/main/java/com/sigopt/model/APIObject.java
+++ b/src/main/java/com/sigopt/model/APIObject.java
@@ -115,7 +115,7 @@ public abstract class APIObject {
  * Used for JSON objects with strictly defined fields.
  */
 class StructObject extends APIObject {
-    final protected Object get(String key) {
+    final public Object get(String key) {
         return this.mapGet(key);
     }
 }

--- a/src/main/java/com/sigopt/model/StructObjectBuilder.java
+++ b/src/main/java/com/sigopt/model/StructObjectBuilder.java
@@ -7,7 +7,7 @@ public class StructObjectBuilder<T extends StructObject> {
         return this.obj;
     }
 
-    final StructObjectBuilder<T> set(String key, Object value) {
+    final public StructObjectBuilder<T> set(String key, Object value) {
         this.obj.set(key, value);
         return this;
     }

--- a/src/test/java/com/sigopt/model/APIObjectTest.java
+++ b/src/test/java/com/sigopt/model/APIObjectTest.java
@@ -1,0 +1,50 @@
+package com.sigopt.model;
+
+import com.sigopt.model.APIResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class APIObjectTest extends APIResourceTestBase {
+    String json;
+
+    @Before
+    public void setUpMockData() throws IOException {
+        json = resource("experiment.json");
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        Experiment exp = APIResource.constructFromJson(json, Experiment.class);
+
+        // Simple case
+        assertEquals(exp.getId(), exp.get("id"));
+
+        // nulls
+        assertNull(exp.getMetric());
+        assertNull(exp.get("metric"));
+
+        // snake_case -> camelCase
+        assertEquals((double) exp.getObservationBudget(), exp.get("observation_budget"));
+    }
+
+    @Test
+    public void testSet() throws Exception {
+        assertEquals(
+            (new Experiment.Builder()).id("1").build(),
+            (new Experiment.Builder()).set("id", "1").build()
+        );
+        assertEquals(
+            (new Experiment.Builder()).observationBudget(23).build(),
+            (new Experiment.Builder()).set("observation_budget", 23).build()
+        );
+    }
+}

--- a/src/test/java/com/sigopt/model/ExperimentTest.java
+++ b/src/test/java/com/sigopt/model/ExperimentTest.java
@@ -2,11 +2,9 @@ package com.sigopt.model;
 
 import com.sigopt.model.APIResource;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -16,10 +14,6 @@ import static org.junit.Assert.assertTrue;
 
 public class ExperimentTest extends APIResourceTestBase {
     String json;
-
-    @BeforeClass
-    public static void setUp() {
-    }
 
     @Before
     public void setUpMockData() throws IOException {


### PR DESCRIPTION
Makes it easier for end users to have access to fields which
haven't been added to Java client yet (as is possible in python
client)