### PR TITLE
Update maven compiler plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <compilerArgs>
                       <arg>-Xlint:all</arg>
                     </compilerArgs>


### PR DESCRIPTION
This PR updates the maven compiler plugin version from 1.6 to 1.7. 
Previously running `mvn test` would fail with this error:
<img width="566" alt="Screen Shot 2019-07-02 at 2 47 03 PM" src="https://user-images.githubusercontent.com/16430092/60549292-47ec1000-9cd9-11e9-8709-ad0b04e9f58d.png">
